### PR TITLE
Pass env to looperEndEvent callback (#19)

### DIFF
--- a/classes/TidalLooper.sc
+++ b/classes/TidalLooper.sc
@@ -174,7 +174,7 @@ TidalLooper {
     			}.play;
 					Routine {
 						(~delta.value + 0.1).wait;
-						looperEndEvent.value();
+						looperEndEvent.value(env);
 
 						if (debugMode, {
 							format("Recording Stopped. [Looper type: % , buffer name: %,  position: %]\n", ~s, ~lname, ~n).post;


### PR DESCRIPTION
Closes #19.
As discussed in the issue, this passes the `env` parameter to `looperEndEvent.value()` so it can be used inside the callback.